### PR TITLE
DB-109 add table prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,16 @@ VENV := .venv
 PYTHON := python3.7
 VERSION := 1.10.0
 
-## build: out/image-id
+## all: dist/pipelinewise-target-snowflake-$(VERSION).tar.gz
 all: dist/pipelinewise-target-snowflake-$(VERSION).tar.gz
 .PHONY: all
 
 clean:
+	rm -rf $(VENV)
+	rm -rf dist
+	rm -rf build
 	rm -rf tmp
-	rm -rf out
+	rm -rf pipelinewise_target_snowflake.egg-info
 .PHONY: clean
 
 tmp/.sentinel.installed-venv: requirements.txt setup.py

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Full list of options in `config.json`:
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
 | no_compression                      | Boolean |            | (Default: False) Generate uncompressed CSV files when loading to Snowflake. Normally, by default GZIP compressed files are generated. |
 | query_tag                           | String  |            | (Default: None) Optional string to tag executed queries in Snowflake. Replaces tokens `{{database}}`, `{{schema}}` and `{{table}}` with the appropriate values. The tags are displayed in the output of the Snowflake `QUERY_HISTORY`, `QUERY_HISTORY_BY_*` functions. |
+| table_prefix                        | String  |            | (Default: None) Optional string to get the target to append a prefix to the table names e.g. "raw_<datasource>". |
 
 ### To run tests:
 

--- a/tests/integration/test_target_snowflake.py
+++ b/tests/integration/test_target_snowflake.py
@@ -39,6 +39,7 @@ class TestIntegration(unittest.TestCase):
 
         # Drop target schema
         if self.config['default_target_schema']:
+            snowflake.query("USE DATABASE {}".format(self.config['dbname']))
             snowflake.query("DROP SCHEMA IF EXISTS {}".format(self.config['default_target_schema']))
 
     def persist_lines(self, lines):
@@ -1093,6 +1094,18 @@ class TestIntegration(unittest.TestCase):
 
     def test_custom_role(self):
         """Test if custom role can be used"""
+        tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
+
+        # Set custom role
+        self.config['role'] = 'invalid-not-existing-role'
+
+        # Using not existing or not authorized role should raise snowflake Database exception:
+        # 250001 (08001): Role 'INVALID-ROLE' specified in the connect string does not exist or not authorized.
+        with assert_raises(DatabaseError):
+            self.persist_lines_with_cache(tap_lines)
+
+    def test_append_table_prefix(self):
+        """Test if """
         tap_lines = test_utils.get_test_tap_lines('messages-with-three-streams.json')
 
         # Set custom role

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -34,8 +34,8 @@ def get_db_config():
     config['client_side_encryption_master_key'] = os.environ.get('CLIENT_SIDE_ENCRYPTION_MASTER_KEY')
 
     # --------------------------------------------------------------------------
-    # The following variables needs to be empty.
-    # The tests cases will set them automatically whenever it's needed
+    # The following variables need to be empty.
+    # The test cases will set them automatically whenever it's needed
     # --------------------------------------------------------------------------
     config['disable_table_cache'] = None
     config['schema_mapping'] = None
@@ -43,6 +43,7 @@ def get_db_config():
     config['hard_delete'] = None
     config['flush_all_streams'] = None
     config['validate_records'] = None
+    config['table_prefix'] = None
 
     return config
 


### PR DESCRIPTION
We add the possibility for users to add a table prefix through the `table_prefix` optional configuration.